### PR TITLE
use dot notation when getting old value (example on only text field)

### DIFF
--- a/src/resources/views/fields/text.blade.php
+++ b/src/resources/views/fields/text.blade.php
@@ -8,7 +8,7 @@
         <input
             type="text"
             name="{{ $field['name'] }}"
-            value="{{ old($field['name']) ? old($field['name']) : (isset($field['value']) ? $field['value'] : (isset($field['default']) ? $field['default'] : '' )) }}"
+            value="{{ old(preg_replace('/\[(.+)\]/U', '.$1', $field['name'])) ? old(preg_replace('/\[(.+)\]/U', '.$1', $field['name'])) : (isset($field['value']) ? $field['value'] : (isset($field['default']) ? $field['default'] : '' )) }}"
             @include('crud::inc.field_attributes')
         >
         @if(isset($field['suffix'])) <div class="input-group-addon">{!! $field['suffix'] !!}</div> @endif


### PR DESCRIPTION
Allows array fields to keep their value when validation fails. Fields named foo[0][bar], for example, will be converted to foo.0.bar when looking up old value (old() doesn't understand square brackets).

I've done this only on the text field for now to get your feedback, if we're happy with it I'll do it for all other applicable fields.